### PR TITLE
Add basic config files to run a celery worker

### DIFF
--- a/django_default_project/celery.py
+++ b/django_default_project/celery.py
@@ -1,0 +1,5 @@
+from celery import Celery
+
+app = Celery("django_default_project")
+app.config_from_object("django_default_project.celeryconfig")
+app.autodiscover_tasks()

--- a/django_default_project/celeryconfig.py
+++ b/django_default_project/celeryconfig.py
@@ -1,0 +1,7 @@
+broker_url = "amqp://admin:password@localhost/django_default_project"
+
+task_always_eager = broker_url == ""
+
+accept_content = ["json"]
+
+worker_hijack_root_logger = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+celery
 django


### PR DESCRIPTION
Celery was added to the project so that updates to `ansible-django-stack` can be made. The config files added allow a celery worker to run - assuming the broker is also running.

There is one possible issue: the url for the broker is hard-wired so it matches the values available when `ansible-django-stack` is run with the molecule tests. This is reasonable but not ideal. One alternative would be to move the broker url to an environment variable  but this has side effects in the `ansible-django-stack` setup. 